### PR TITLE
INTERLOK-3403 Upgrade to mockito 3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,11 +123,11 @@ subprojects {
 
     annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
 
-    testCompile  ("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-    testCompile  ("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
-    testCompile ("org.mockito:mockito-all:1.10.19")
-    testCompile ('junit:junit:4.13.1')
-    testCompile "org.slf4j:slf4j-simple:$slf4jVersion"
+    testCompile ("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
+    testCompile ("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
+    testCompile ("org.mockito:mockito-core:3.7.0")
+    testCompile ("org.mockito:mockito-inline:3.7.0")
+    testCompile ("org.slf4j:slf4j-simple:$slf4jVersion")
     // exclude any log4j dependencies so that we can just use slf4j simple.
     // works around INTERLOk-3233
     testCompile "com.adaptris:interlok-stubs:$interlokCoreVersion", {

--- a/interlok-kubernetes-metrics/build.gradle
+++ b/interlok-kubernetes-metrics/build.gradle
@@ -45,6 +45,8 @@ publishing {
         properties.appendNode("target", "3.9.1+")
         properties.appendNode("license", "false")
         properties.appendNode("tags", "kubernetes,metrics,management")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-kubernetes")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-kubernetes/raw/develop/README.md")
       }
     }
   }

--- a/interlok-kubernetes-prometheus/build.gradle
+++ b/interlok-kubernetes-prometheus/build.gradle
@@ -56,6 +56,8 @@ publishing {
         properties.appendNode("target", "3.9.1+")
         properties.appendNode("license", "false")
         properties.appendNode("tags", "prometheus,kubernetes,metrics,management")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-kubernetes")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-kubernetes/raw/develop/README.md")
       }
     }
   }

--- a/interlok-kubernetes-prometheus/src/test/java/com/adaptris/kubernetes/metrics/prometheus/JmxMessageMetricsCollectorTest.java
+++ b/interlok-kubernetes-prometheus/src/test/java/com/adaptris/kubernetes/metrics/prometheus/JmxMessageMetricsCollectorTest.java
@@ -1,11 +1,7 @@
 package com.adaptris.kubernetes.metrics.prometheus;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import static org.mockito.Matchers.any;
-
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +17,7 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.QueryExp;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -33,73 +30,78 @@ import com.adaptris.core.interceptor.MessageStatistic;
 public class JmxMessageMetricsCollectorTest {
 
   private JmxMessageMetricsCollector collector;
-  
+
   @Mock private MBeanServer mockMBeanServer;
-  
+
   private Set<ObjectInstance> objectSet;
-  
+
   @Mock private ObjectInstance mockObjectInstance;
-  
+
   @Mock private ObjectName mockObjectName;
-  
+
   private ObjectName realObjectName;
-  
-  @Mock private MessageMetricsStatisticsMBean mockMMSMBean; 
-  
+
+  @Mock private MessageMetricsStatisticsMBean mockMMSMBean;
+
   private List<MessageStatistic> messagesStatisticsList;
-  
+
   @Mock MessageMetricsListener mockListener;
-  
+
+  private AutoCloseable closeable;
+
   @BeforeEach
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
+    closeable = MockitoAnnotations.openMocks(this);
+
     collector = new JmxMessageMetricsCollector();
     collector.setInterlokMBeanServer(mockMBeanServer);
-    
+
     objectSet = new HashSet<>();
     objectSet.add(mockObjectInstance);
-    
+
     realObjectName = new ObjectName("com.adaptris:type=Metrics,adapter=adapter,channel=channel,workflow=workflow");
-    
-    messagesStatisticsList = new ArrayList<MessageStatistic>();
-    
+
+    messagesStatisticsList = new ArrayList<>();
+
     when(mockMBeanServer.queryMBeans(any(ObjectName.class), any(QueryExp.class)))
-        .thenReturn(objectSet);
-    
+    .thenReturn(objectSet);
+
     when(mockMMSMBean.getStatistics())
-        .thenReturn(messagesStatisticsList);
+    .thenReturn(messagesStatisticsList);
   }
-  
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    closeable.close();
+  }
+
   @Test
   public void testMBeansLoadedFirstExecution() {
-    when(mockObjectInstance.getClassName())
-        .thenReturn(MessageMetricsStatistics.class.getName());
-    when(mockObjectInstance.getObjectName())
-        .thenReturn(mockObjectName);
-    
+    when(mockObjectInstance.getClassName()).thenReturn(MessageMetricsStatistics.class.getName());
+    when(mockObjectInstance.getObjectName()).thenReturn(mockObjectName);
+
     try {
       collector.run();
     } catch (Throwable t) {};
-    
-    verify(mockMBeanServer).queryMBeans(any(ObjectName.class), any(QueryExp.class));
+
+    verify(mockMBeanServer).queryMBeans(any(ObjectName.class), isNull());
   }
-  
-  @Test 
+
+  @Test
   public void testNotifyNewStats() throws Exception {
-    Map<ObjectName, MessageMetricsStatisticsMBean> mbeans = new HashMap<ObjectName, MessageMetricsStatisticsMBean>();
+    Map<ObjectName, MessageMetricsStatisticsMBean> mbeans = new HashMap<>();
     mbeans.put(realObjectName, mockMMSMBean);
-    
+
     collector.registerListener(mockListener);
-    
+
     collector.setMetricsMBeans(mbeans);
     collector.run();
-    
+
     collector.deregisterListener(mockListener);
-    
+
     Thread.sleep(500);
-    
+
     verify(mockListener).notifyMessageMetrics(any());
   }
-  
+
 }

--- a/interlok-kubernetes-prometheus/src/test/java/com/adaptris/kubernetes/metrics/prometheus/PrometheusMetricsAdapterTest.java
+++ b/interlok-kubernetes-prometheus/src/test/java/com/adaptris/kubernetes/metrics/prometheus/PrometheusMetricsAdapterTest.java
@@ -2,8 +2,7 @@ package com.adaptris.kubernetes.metrics.prometheus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Matchers.any;
-
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -15,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -24,87 +24,94 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 
 public class PrometheusMetricsAdapterTest {
-  
+
   private PrometheusMetricsAdapter adapter;
-  
+
   @Mock private PushGateway mockPushGateway;
-  
+
   @Mock private MessageMetricsCollector mockMetricsCollctor;
-  
+
   @Mock private MetricsCalculator mockCalculator;
-    
+
+  private AutoCloseable closeable;
+
   @BeforeEach
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
+    closeable = MockitoAnnotations.openMocks(this);
+
     adapter = new PrometheusMetricsAdapter();
     adapter.setPushGateway(mockPushGateway);
   }
-  
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    closeable.close();
+  }
+
   @Test
   public void testInitLoadPropertiesDefauls() throws Exception {
     System.setProperty("K8S_NAMESPACE", "");
     System.setProperty("K8S_POD_NAME", "");
     adapter.init();
-    
+
     assertEquals("default", adapter.getMetricLabels().get("k8s_namespace"));
     assertEquals("interlok", adapter.getMetricLabels().get("k8s_pod_name"));
-    
+
     assertEquals(PrometheusMetricsAdapter.class.getSimpleName(), adapter.getImplementationName());
   }
-  
+
   @Test
   public void testInitLoadPropertiesSystem() throws Exception {
     System.setProperty("K8S_NAMESPACE", "system_namespace");
     System.setProperty("K8S_POD_NAME", "system_pod_name");
-    
+
     adapter.init();
-    
+
     assertEquals("system_namespace", adapter.getMetricLabels().get("k8s_namespace"));
     assertEquals("system_pod_name", adapter.getMetricLabels().get("k8s_pod_name"));
   }
-  
+
   @Test
   public void testInitLoadEndpointPropertiesSystem() throws Exception {
     System.setProperty("prometheusEndpointUrl", "localhost:9090");
-    
+
     adapter.setPushGateway(null);
     adapter.init();
-    
+
     Field field = adapter.getPushGateway().getClass().getDeclaredField("gatewayBaseURL");
     field.setAccessible(true);
 
     Object value = field.get(adapter.getPushGateway());
-    
+
     assertEquals("http://localhost:9090/metrics/", value);
   }
-  
+
   @Test
   public void testInitLoadEndpointBootstrap() throws Exception {
     System.setProperty("prometheusEndpointUrl", "");
-    
+
     Properties bootstrapProperties = new Properties();
     bootstrapProperties.put("prometheusEndpointUrl", "localhost:9095");
-    
+
     adapter.setBootstrapProperties(bootstrapProperties);
     adapter.setPushGateway(null);
     adapter.init();
-    
+
     Field field = adapter.getPushGateway().getClass().getDeclaredField("gatewayBaseURL");
     field.setAccessible(true);
 
     Object value = field.get(adapter.getPushGateway());
-    
+
     assertEquals("http://localhost:9095/metrics/", value);
   }
-  
+
   @Test
   public void testInitNoLoadEndpoint() throws Exception {
     System.setProperty("prometheusEndpointUrl", "");
-    
+
     adapter.setPushGateway(null);
     adapter.init();
-    
+
     assertNull(adapter.getPushGateway());
   }
 
@@ -112,53 +119,53 @@ public class PrometheusMetricsAdapterTest {
   public void testStartPullsMetrics() throws Exception {
     adapter.setCollectorIntervalSeconds(1);
     adapter.setMessageMetricsCollector(mockMetricsCollctor);
-    
+
     adapter.init();
     adapter.start();
-    
+
     Thread.sleep(2000);
-    
+
     adapter.stop();
     adapter.close();
-    
+
     verify(mockMetricsCollctor, atLeast(1)).run();
   }
-  
+
   @Test
   public void testSendToPrometheus() throws Exception {
-    List<MessageStatisticExtended> statistics = new ArrayList<MessageStatisticExtended>();
+    List<MessageStatisticExtended> statistics = new ArrayList<>();
     MessageStatisticExtended stat = new MessageStatisticExtended();
     stat.setStatisticId("MyStatId");
     statistics.add(stat);
-    
+
     when(mockCalculator.calculateMessagesPerSecond(10l, stat))
-        .thenReturn(10l);
-    
+    .thenReturn(10l);
+
     adapter.setCalculator(mockCalculator);
     adapter.init();
-    
+
     adapter.notifyMessageMetrics(statistics);
-    
+
     verify(mockPushGateway).pushAdd(any(CollectorRegistry.class), any(String.class), any(HashMap.class));
   }
-  
+
   @Test
   public void testDoesNotSendToPrometheus() throws Exception {
-    List<MessageStatisticExtended> statistics = new ArrayList<MessageStatisticExtended>();
+    List<MessageStatisticExtended> statistics = new ArrayList<>();
     MessageStatisticExtended stat = new MessageStatisticExtended();
     stat.setStatisticId("MyStatId");
     statistics.add(stat);
-    
+
     when(mockCalculator.calculateMessagesPerSecond(10l, stat))
-        .thenReturn(-1l);
-    
+    .thenReturn(-1l);
+
     adapter.setCalculator(mockCalculator);
     adapter.init();
-    
+
     adapter.notifyMessageMetrics(statistics);
-    
+
     verify(mockPushGateway, never()).pushAdd(any(CollectorRegistry.class), any(String.class), any(HashMap.class));
   }
-  
+
 
 }


### PR DESCRIPTION
## Motivation

We want to upgrade all optional components to use the latest version of mockito

## Modification

- Upgrade to mockito 3.7.0
- Use mockito 3 ArgumentMatchers
- Remove dependency on junit 4. If we use junit 5 there is no need to keep it.
- Add repository and readme information for INTERLOK-3187

## Result

Upgrade done

## Testing

gradlew check should work.
