### PR TITLE
Update build.gradle

### DIFF
--- a/interlok-kubernetes-prometheus/build.gradle
+++ b/interlok-kubernetes-prometheus/build.gradle
@@ -51,7 +51,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Management component for exposing metrics to Prometheus in Kuberenetes.")
-        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/advanced-interlok-scaling.html")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-interlok-scaling")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.9.1+")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.